### PR TITLE
Exception for "Schedule" button

### DIFF
--- a/inc/publish-confirm.php
+++ b/inc/publish-confirm.php
@@ -143,7 +143,7 @@ class Publish_Confirm {
 					$( '#publish' ).on(
 						'click',
 						function( event ) {
-							if ( $( this ).attr( 'name' ) !== 'publish' ) {
+							if ( $( this ).attr( 'name' ) !== 'publish' || $( this ).attr( 'value' ) == 'Schedule' ) {
 								return;
 							}
 							if ( ! confirm( <?php echo wp_json_encode( $msg ) ?> ) ) {

--- a/inc/publish-confirm.php
+++ b/inc/publish-confirm.php
@@ -143,7 +143,7 @@ class Publish_Confirm {
 					$( '#publish' ).on(
 						'click',
 						function( event ) {
-							if ( $( this ).attr( 'name' ) !== 'publish' || $( this ).attr( 'value' ) == 'Schedule' ) {
+							if ( $( this ).attr( 'name' ) !== 'publish' || $( this ).attr( 'value' ) === 'Schedule' ) {
 								return;
 							}
 							if ( ! confirm( <?php echo wp_json_encode( $msg ) ?> ) ) {

--- a/inc/publish-confirm.php
+++ b/inc/publish-confirm.php
@@ -140,10 +140,11 @@ class Publish_Confirm {
 		<script type="text/javascript">
 			jQuery( document ).ready(
 				function( $ ) {
+					var scheduleLabel = postL10n.schedule; // if the language is English, this is "Schedule"
 					$( '#publish' ).on(
 						'click',
 						function( event ) {
-							if ( $( this ).attr( 'name' ) !== 'publish' || $( this ).attr( 'value' ) === 'Schedule' ) {
+							if ( $( this ).attr( 'name' ) !== 'publish' || $( this ).attr( 'value' ) === scheduleLabel ) {
 								return;
 							}
 							if ( ! confirm( <?php echo wp_json_encode( $msg ) ?> ) ) {


### PR DESCRIPTION
At least in recent versions of Wordpress including 4.7.2, this is showing the same confirmation message for the "Schedule" button as for the "Publish" button. This pull request makes it so that the confirmation message appears only for Publish, not Schedule.

Alternatively, there could still be a confirmation for scheduling but the confirmation message would be adjusted accordingly. It's a bit confusing if the message said "Are you sure you want to _publish_ this now?" if the user clicked "Schedule".

(Note: the Schedule button still has its "name" and "id" attributes set to "publish", so the only way to differentiate it is to check the "value" attribute. One option would have been to assume that the confirmation shouldn't appear unless the "value" of the button is "Publish", but it seemed a bit safer to check specifically for a button with a "value" of "Schedule", so that's what I did.)

BTW, thanks for this useful plugin.